### PR TITLE
Fix relative time rendering

### DIFF
--- a/lib/oban/live_dashboard.ex
+++ b/lib/oban/live_dashboard.ex
@@ -276,7 +276,7 @@ defmodule Oban.LiveDashboard do
   defp format_relative(%DateTime{} = a, %DateTime{} = b) do
     delta = DateTime.diff(a, b, :second)
     {prefix, suffix} = if delta < 0, do: {"", " ago"}, else: {"in ", ""}
-    {d, {h, m, s}} = :calendar.seconds_to_daystime(div(delta, 1000))
+    {d, {h, m, s}} = :calendar.seconds_to_daystime(delta)
 
     cond do
       d > 1 -> "#{d} days"


### PR DESCRIPTION
Thanks for making this project!

I noticed that the values of the "Scheduled at" column in my application were all extremely small, e.g. "in 3 seconds", despite `scheduled_at` in the database being an hour in the future. It looks like this is because we compute `delta` in `:second`s but then divide by 1000 before passing it to `:calendar.seconds_to_daystime`. Maybe `delta` used to be in milliseconds.